### PR TITLE
Use node[ipaddress] instead of node[ip], which doesn't seem to work

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -65,7 +65,7 @@ default['mesos']['slave']['flags']['isolation']     = 'posix/cpu,posix/mem'
 default['mesos']['slave']['flags']['master']        = 'zk://127.0.0.1:2181/mesos'
 default['mesos']['slave']['flags']['strict']        = true
 default['mesos']['slave']['flags']['recover']       = 'reconnect'
-default['mesos']['slave']['flags']['ip']            = node[:ip]
+default['mesos']['slave']['flags']['ip']            = node[:ipaddress]
 
 # Workaround for setting default cgroups hierarchy root
 default['mesos']['slave']['flags']['cgroups_hierarchy'] = if node['mesos']['init'] == 'systemd'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'infra@duedil.com'
 license          'Apache 2.0'
 description      'Installs/Configures Apache Mesos'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.6.0'
+version          '3.6.1'
 source_url       'https://github.com/duedil-ltd/mesos_cookbook'
 issues_url       'https://github.com/duedil-ltd/mesos_cookbook/issues'
 


### PR DESCRIPTION
Both our old cookbook and the Chef docs use :node["ipaddress"]